### PR TITLE
feat: enable GitHub annotations for linting

### DIFF
--- a/.github/pytype-problem-matcher.json
+++ b/.github/pytype-problem-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "pytype",
+      "pattern": [
+        {
+          "regexp": "^(.*?):(\\d+):(\\d+):\\s+error: (.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "severity": "error"
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,6 +79,8 @@ jobs:
           persist-credentials: false
       - name: Set up Hatch
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
+      - name: Register pytype problem matcher
+        run: echo "::add-matcher::.github/pytype-problem-matcher.json"
       - name: Run type check
         run: hatch run type:check
 
@@ -96,3 +98,5 @@ jobs:
         uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
       - name: Run python linting
         run: hatch fmt --check
+        env:
+          RUFF_OUTPUT_FORMAT: github


### PR DESCRIPTION
## Summary
- show pytype results as PR annotations
- output ruff lint errors using GitHub format

## Testing
- `hatch fmt --check`
- `hatch run type:check`


------
https://chatgpt.com/codex/tasks/task_e_6890da9be2f8832a9b09bc69d4844efb